### PR TITLE
Omit unnecessary bits when explicit conversion operators are supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,18 @@
 #
 # Instructions for customizing this script for your library:
 # 
-# 1. Customize the compilers and language levels you want.
-# 2. If you have move than include/, src/, test/, example/, examples/,
-#    benchmark/ or tools/ directories, set the environment variable DEPINST.
-#    For example if your build uses code in "bench/" and "fog/" directories:
-#        - DEPINST="--include bench --include fog"
+# 1. Customize the compilers and language levels you want in the 'jobs'.
+# 2. If you have more than include/, src/, test/, example/, examples/, or
+#    tools/ directories, modify your Travis CI project and add the environment
+#    variable DEPINST.  For example if your build uses code in "bench/" and
+#    "fog/" directories, then set DEPINST to the following:
+#        --include bench --include fog
 # 3. If you want to enable Coverity Scan, you need to provide the environment
 #    variables COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL in
 #    your github settings.
 # 4. Enable pull request builds in your boostorg/<library> account.
-# 5. The default language level is C++03, you can change CXXSTD to modify it.
 #
 # That's it - the scripts will do everything else for you.
-#
 
 sudo: false
 dist: trusty
@@ -34,8 +33,6 @@ env:
   # - B2_LINK=link=shared,static
   # - B2_THREADING=threading=multi,single
     - B2_VARIANT=variant=release,debug
-  # - CXXSTD=03
-  # - DEPINST="--include other"
 
 install:
   - git clone https://github.com/jeking3/boost-ci.git boost-ci
@@ -58,46 +55,62 @@ script:
   - cd $BOOST_ROOT/libs/$SELF
   - ci/travis/build.sh
 
+#
+# Default toolsets in Ubuntu
+#
+#       trusty xenial bionic
+#        14.04  16.04  18.04
+#       ------ ------ ------
+# clang    3.4    3.8    6.0
+#   gcc  4.8.2  5.3.1  7.3.0
+#
+
+anchors:
+  clang-34: &clang-34 { apt: { packages: [ "clang-3.4" ], sources: [ "llvm-toolchain-trusty-3.4" ] } }
+  clang-38: &clang-38 { apt: { packages: [ "clang-3.8" ], sources: [ "llvm-toolchain-trusty-3.8" ] } }
+  clang-4:  &clang-4  { apt: { packages: [ "clang-4.0" ], sources: [ "llvm-toolchain-trusty-4.0" ] } }
+  clang-5:  &clang-5  { apt: { packages: [ "clang-5.0" ], sources: [ "llvm-toolchain-trusty-5.0" ] } }
+  clang-6:  &clang-6  { apt: { packages: [ "clang-6.0",
+                                           "libstdc++-7-dev",
+                                           "valgrind"  ], sources: [ "llvm-toolchain-trusty-6.0",
+                                                                     "ubuntu-toolchain-r-test"   ] } }
+  gcc-44:   &gcc-44   { apt: { packages: [ "g++-4.4"   ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-46:   &gcc-46   { apt: { packages: [ "g++-4.6"   ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-48:   &gcc-48   { apt: { packages: [ "g++-4.8"   ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-5:    &gcc-5    { apt: { packages: [ "g++-5"     ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-6:    &gcc-6    { apt: { packages: [ "g++-6"     ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-7:    &gcc-7    { apt: { packages: [ "g++-7"     ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-8:    &gcc-8    { apt: { packages: [ "g++-8"     ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+
 jobs:
   include:
-    #################### Jobs to run on every pull request ####################
+    # libstdc++
+    - { os: "linux", env: [ "TOOLSET=gcc-4.4",   "CXXSTD=98,0x"          ], addons: *gcc-44    }
+    - { os: "linux", env: [ "TOOLSET=gcc-4.6",   "CXXSTD=03,0x"          ], addons: *gcc-46    }
+    - { os: "linux", env: [ "TOOLSET=gcc-4.8",   "CXXSTD=03,11"          ], addons: *gcc-48    }
+    - { os: "linux", env: [ "TOOLSET=gcc-5",     "CXXSTD=03,11"          ], addons: *gcc-5     }
+    - { os: "linux", env: [ "TOOLSET=gcc-6",     "CXXSTD=03,11,14"       ], addons: *gcc-6     }
+    - { os: "linux", env: [ "TOOLSET=gcc-7",     "CXXSTD=03,11,14,17"    ], addons: *gcc-7     }
+    - { os: "linux", env: [ "TOOLSET=gcc-8",     "CXXSTD=03,11,14,17,2a" ], addons: *gcc-8     }
+    - { os: "linux", env: [ "TOOLSET=clang-3.4", "CXXSTD=03,11,14"       ], addons: *clang-34  }
+    - { os: "linux", env: [ "TOOLSET=clang-3.8", "CXXSTD=03,11,14"       ], addons: *clang-38  }
+    - { os: "linux", env: [ "TOOLSET=clang-4.0", "CXXSTD=03,11,14"       ], addons: *clang-4   }
+    - { os: "linux", env: [ "TOOLSET=clang-5.0", "CXXSTD=03,11,14,17"    ], addons: *clang-5   }
+    - { os: "linux", env: [ "TOOLSET=clang-6.0", "CXXSTD=03,11,14,17,2a" ], addons: *clang-6   }
+    # libc++
+  # the rvm environment on osx is taking over basic commands like "cd" and breaking things
+  # - { os: "osx"  , env: [ "COMMENT=libc++",
+  #                         "TOOLSET=clang",     "CXXSTD=03,11,14"       ]                     }
+
     - os: linux
       env: 
-        - COMMENT="C++03"
-        - TOOLSET=gcc,gcc-7,clang
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-    - os: linux
-      env: 
-        - COMMENT="C++11"
-        - TOOLSET=gcc,gcc-7,clang
-        - CXXSTD=11
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-    - os: linux
-      env: 
-        - COMMENT=valgrind
-        - TOOLSET=clang 
-        - B2_VARIANT=variant=debug
-        - TESTFLAGS=testing.launcher=valgrind
-        - VALGRIND_OPTS=--error-exitcode=1
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-            - libstdc++-7-dev
-            - valgrind
-          sources:
-            - llvm-toolchain-trusty-5.0
-            - ubuntu-toolchain-r-test
+        - COMMENT=codecov.io
+        - TOOLSET=gcc-7
+      addons: *gcc-7
+      script:
+        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && export PATH=/tmp/lcov/bin:$PATH && which lcov && lcov --version && popd
+        - cd $BOOST_ROOT/libs/$SELF
+        - ci/travis/codecov.sh
 
     - os: linux
       env:
@@ -108,43 +121,23 @@ jobs:
 
     - os: linux
       env:
-        - COMMENT=UBSAN
+        - COMMENT=ubsan
         - B2_VARIANT=variant=debug
-        - TOOLSET=gcc-7
+        - TOOLSET=gcc-8
         - CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
         - LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined linkflags=-fuse-ld=gold"
         - UBSAN_OPTIONS=print_stacktrace=1
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
+      addons: *gcc-8
 
     - os: linux
-      env: 
-        - COMMENT=CodeCov
-        - TOOLSET=gcc-7
-      addons:
-        apt:
-          packages:
-            - gcc-7
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-      script:
-        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && export PATH=/tmp/lcov/bin:$PATH && which lcov && lcov --version && popd
-        - cd $BOOST_ROOT/libs/$SELF
-        - ci/travis/codecov.sh
-
-  # does not work with sourced install shell yet: see 
-  # https://travis-ci.org/jeking3/tokenizer/jobs/384903189
-  # for a typical failure
-  # - os: osx
-  #   osx_image: xcode9
-  #   env:
-  #     - TOOLSET=clang
-  #     - CXXSTD=03,11
+      env:
+        - COMMENT=valgrind
+        - TOOLSET=clang-6.0
+        - CXXSTD=03
+        - B2_VARIANT=variant=debug
+        - TESTFLAGS=testing.launcher=valgrind
+        - VALGRIND_OPTS=--error-exitcode=1
+      addons: *clang-6
 
     #################### Jobs to run on pushes to master, develop ###################
 
@@ -153,7 +146,8 @@ jobs:
       if: (env(COVERITY_SCAN_NOTIFICATION_EMAIL) IS present) AND (branch IN (develop, master)) AND (type IN (cron, push))
       env:
         - COMMENT="Coverity Scan"
-        - TOOLSET=gcc
+        - TOOLSET=gcc-7
+      addons: *gcc-7
       script:
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/coverity.sh

--- a/include/boost/logic/tribool.hpp
+++ b/include/boost/logic/tribool.hpp
@@ -71,6 +71,7 @@ indeterminate(tribool x,
  */
 class tribool
 {
+#if defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS )
 private:
   /// INTERNAL ONLY
   struct dummy {
@@ -78,6 +79,7 @@ private:
   };
 
   typedef void (dummy::*safe_bool)();
+#endif
 
 public:
   /**

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,10 +8,55 @@
 
 # For more information, see http://www.boost.org/
 
+import path ;
+import os ;
+import regex ;
+import testing ;
+
+local self = logic ;
+
+rule test-expected-failures
+{
+    local all_rules = ;
+    local file ;
+    local tests_path = [ path.make $(BOOST_ROOT)/libs/$(self)/test/compile-fail ] ;
+    for file in [ path.glob-tree $(tests_path) : *.cpp ]
+    {
+        local rel_file = [ path.relative-to $(tests_path) $(file) ] ;
+        local test_name = [ regex.replace [ regex.replace $(rel_file) "/" "-" ] ".cpp" "" ] ;
+        local decl_test_name = cf-$(test_name) ;
+        # ECHO $(rel_file) ;
+        all_rules += [ compile-fail $(file) : : $(decl_test_name) ] ;
+    }
+
+    # ECHO All rules: $(all_rules) ;
+    return $(all_rules) ;
+}
+
+rule test-header-isolation
+{
+    local all_rules = ;
+    local file ;
+    local headers_path = [ path.make $(BOOST_ROOT)/libs/$(self)/include ] ;
+    for file in [ path.glob-tree $(headers_path) : *.hpp ]
+    {
+        local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
+        # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
+        #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
+        local test_name = [ regex.replace $(rel_file) "/" "-" ] ;
+        local decl_test_name = ~hdr-decl-$(test_name) ;
+        # ECHO $(rel_file) ;
+        all_rules += [ compile compile/decl_header.cpp : <define>"BOOST_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(decl_test_name) ] ;
+    }
+
+    # ECHO All rules: $(all_rules) ;
+    return $(all_rules) ;
+}
+
   test-suite logic  : 
+    [ test-expected-failures ]
+    [ test-header-isolation ]
     [ run tribool_test.cpp ]
     [ run tribool_rename_test.cpp ]
     [ run tribool_io_test.cpp ]
    ;
-
-      

--- a/test/compile-fail/implicit.cpp
+++ b/test/compile-fail/implicit.cpp
@@ -1,0 +1,23 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::indeterminate;
+  using boost::logic::tribool;
+
+  tribool i(indeterminate);
+
+#if !defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS )
+  bool b = i; // expect to see: no viable conversion from 'boost::logic::tribool' to 'bool'
+  return (int)b;
+#else
+#error in c++03 explicit conversions are allowed
+#endif
+  // NOTREACHED
+  return 0;
+}

--- a/test/compile-fail/implicit_int_1.cpp
+++ b/test/compile-fail/implicit_int_1.cpp
@@ -1,0 +1,16 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::indeterminate;
+  using boost::logic::tribool;
+
+  tribool i(indeterminate);
+
+  return i; // expect to see: error: no viable conversion from returned value of type 'boost::logic::tribool' to function return type 'int'
+}

--- a/test/compile-fail/implicit_int_2.cpp
+++ b/test/compile-fail/implicit_int_2.cpp
@@ -1,0 +1,16 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::indeterminate;
+  using boost::logic::tribool;
+
+  tribool i(indeterminate);
+
+  return i + 1; // expect to see: error: invalid operands to binary expression ('boost::logic::tribool' and 'int')
+}

--- a/test/compile-fail/implicit_int_3.cpp
+++ b/test/compile-fail/implicit_int_3.cpp
@@ -1,0 +1,16 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::indeterminate;
+  using boost::logic::tribool;
+
+  tribool i(indeterminate);
+
+  return i << 1; // expect to see: error: invalid operands to binary expression ('boost::logic::tribool' and 'int')
+}

--- a/test/compile-fail/operator_less_1.cpp
+++ b/test/compile-fail/operator_less_1.cpp
@@ -1,0 +1,16 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::tribool;
+
+  tribool f;       // false
+  tribool t(true); // true
+
+  return f < t; // expect to see: error: invalid operands to binary expression ('boost::logic::tribool' and 'boost::logic::tribool')
+}

--- a/test/compile-fail/operator_less_2.cpp
+++ b/test/compile-fail/operator_less_2.cpp
@@ -1,0 +1,15 @@
+// Copyright 2018 James E. King III. Use, modification and
+// distribution is subject to the Boost Software License, Version
+// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/logic/tribool.hpp>
+
+int main(int, char*[])
+{
+  using boost::logic::tribool;
+
+  tribool t(true);
+
+  return t < 1; // expect to see: error: invalid operands to binary expression ('boost::logic::tribool' and 'int')
+}

--- a/test/compile/decl_header.cpp
+++ b/test/compile/decl_header.cpp
@@ -1,0 +1,24 @@
+/*
+ *             Copyright Andrey Semashev 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   decl_header.cpp
+ * \author Andrey Semashev
+ * \date   21.06.2015
+ *
+ * \brief  This file contains a test boilerplate for checking that every
+ *         public header is self-contained and does not have any missing
+ *         #includes.
+ */
+
+#define BOOST_TEST_INCLUDE_HEADER() <BOOST_TEST_HEADER>
+
+#include BOOST_TEST_INCLUDE_HEADER()
+
+int main(int, char*[])
+{
+    return 0;
+}

--- a/test/tribool_test.cpp
+++ b/test/tribool_test.cpp
@@ -3,7 +3,7 @@
 // 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/core/ignore_unused.hpp>
+#include <boost/config.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/test/minimal.hpp>
 #include <iostream>
@@ -15,6 +15,19 @@ int test_main(int, char*[])
   tribool x; // false
   tribool y(true); // true
   tribool z(indeterminate); // indeterminate
+
+#if defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS )
+  // c++03 allows for implicit conversion to bool
+  // c++11 uses an explicit conversion operator so this would not compile
+  //       and that is tested in the compile-fail/implicit.cpp file
+  // so we check the conversion to ensure it is sane
+  bool bx = x;
+  BOOST_CHECK(bx == false);
+  bool by = y;
+  BOOST_CHECK(by == true);
+  bool bz = z;
+  BOOST_CHECK(bz == false);
+#endif
 
   BOOST_CHECK(!x);
   BOOST_CHECK(x == false);
@@ -115,7 +128,7 @@ int test_main(int, char*[])
     BOOST_CHECK(false);
   }
 
-#ifndef BOOST_NO_CXX11_CONSTEXPR
+#if !defined(BOOST_NO_CXX11_CONSTEXPR) 
   constexpr bool res_ors = indeterminate(false || tribool(false) || false || indeterminate); // true
   BOOST_CHECK(res_ors);
   char array_ors[res_ors ? 2 : 3];
@@ -127,9 +140,13 @@ int test_main(int, char*[])
   BOOST_CHECK(sizeof(array_ands) / sizeof(char) == 3);
 
   constexpr bool res_safe_bool = static_cast<bool>( tribool(true) );
-  boost::ignore_unused(res_safe_bool);
-  constexpr tribool xxx = (tribool(true) || tribool(indeterminate));
-  static_assert(xxx, "Must be true!");
+  BOOST_STATIC_ASSERT(res_safe_bool);
+
+// gcc 4.6 chokes on the xxx assignment
+# if !BOOST_WORKAROUND(BOOST_GCC, < 40700)
+    constexpr tribool xxx = (tribool(true) || tribool(indeterminate));
+    BOOST_STATIC_ASSERT(xxx);
+# endif
 #endif
 
   std::cout << "no errors detected\n";


### PR DESCRIPTION
This continues #11 which continues #7.