### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Logic is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+project( BoostLogic LANGUAGES CXX )
+
+add_library( boost_logic INTERFACE )
+add_library( Boost::logic ALIAS boost_logic )
+
+target_include_directories( boost_logic INTERFACE include )
+
+target_link_libraries( boost_logic
+    INTERFACE
+        Boost::config
+        Boost::core
+)


### PR DESCRIPTION
Supports the use of boost logic as part of a
parent cmake project via add_subdirectory( libs/logic )

Some more information can be found on the ML: https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M%5B1-25%5D