### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/logic/tribool.hpp
+++ b/include/boost/logic/tribool.hpp
@@ -30,7 +30,7 @@ namespace detail {
  */
 struct indeterminate_t
 {
-#if BOOST_WORKAROUND(__BORLANDC__, < 0x0600)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0600)
   char dummy_; // BCB would use 8 bytes by default
 #endif
 };


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.