### PR TITLE
Use `unsigned char` as the underlying type for the tribool state

### DIFF
--- a/include/boost/logic/tribool.hpp
+++ b/include/boost/logic/tribool.hpp
@@ -131,7 +131,11 @@ public:
    * The actual stored value in this 3-state boolean, which may be false, true,
    * or indeterminate.
    */
-  enum value_t { false_value, true_value, indeterminate_value } value;
+  enum value_t
+#if !defined( BOOST_NO_CXX11_SCOPED_ENUMS )
+    : unsigned char
+#endif
+  { false_value, true_value, indeterminate_value } value;
 };
 
 // Check if the given tribool has an indeterminate value. Also doubles as a


### PR DESCRIPTION
This makes `sizeof(tribool) == 1`, which is similar to `sizeof(bool)` on most platforms. This is only enabled when C++11 scoped enums are supported.