### PR TITLE
Fix mistakes

### DIFF
--- a/doc/tribool.boostbook
+++ b/doc/tribool.boostbook
@@ -191,7 +191,7 @@ cout &lt;&lt; boolalpha &lt;&lt; x; // Produces "false", "true", or "indetermina
   string naming the indeterminate type is contained in the
   <code><classname>indeterminate_name</classname></code> facet. To
   replace the name of the indeterminate state, you need to imbue your
-  stream with a local containing a
+  stream with a local containing an
   <code><classname>indeterminate_name</classname></code> facet, e.g.:</para>
 
   <programlisting><macroname>BOOST_TRIBOOL_THIRD_STATE</macroname>(maybe)
@@ -201,7 +201,7 @@ cout.imbue(test_locale);
 <classname>tribool</classname> x(maybe);
 cout &lt;&lt; boolalpha &lt;&lt; x &lt;&lt; endl; // Prints "maybe"</programlisting>
 
-  <para>If you C++ standard library implementation does not support
+  <para>If your C++ standard library implementation does not support
   locales, <code>tribool</code> input/output will still work, but you
   will be unable to customize the strings printed/parsed when
   <code>boolalpha</code> is set.</para>

--- a/include/boost/logic/tribool.hpp
+++ b/include/boost/logic/tribool.hpp
@@ -48,9 +48,9 @@ typedef bool (*indeterminate_keyword_t)(tribool, detail::indeterminate_t);
 /**
  * \brief Keyword and test function for the indeterminate tribool value
  *
- * The \c indeterminate function has a dual role. It's first role is
+ * The \c indeterminate function has a dual role. Its first role is
  * as a unary function that tells whether the tribool value is in the
- * "indeterminate" state. It's second role is as a keyword
+ * "indeterminate" state. Its second role is as a keyword
  * representing the indeterminate (just like "true" and "false"
  * represent the true and false states). If you do not like the name
  * "indeterminate", and would prefer to use a different name, see the

--- a/include/boost/logic/tribool_io.hpp
+++ b/include/boost/logic/tribool_io.hpp
@@ -140,7 +140,7 @@ public:
   /// Returns the name for the indeterminate value
   string_type name() const { return name_; }
 
-  /// Uniquily identifies this facet with the locale.
+  /// Uniquely identifies this facet with the locale.
   static std::locale::id id;
 
 private:
@@ -224,7 +224,7 @@ operator<<(std::basic_ostream<CharT, Traits>& out,
  * function reads a \c long value from the input stream @p in and
  * converts that value to a tribool. If that value is 0, @p x becomes
  * \c false; if it is 1, @p x becomes \c true; if it is 2, @p becomes
- * \c indetermine; otherwise, the operation fails (and the fail bit is
+ * \c indeterminate; otherwise, the operation fails (and the fail bit is
  * set on the input stream @p in).
  *
  * When <tt>(out.flags() & std::ios_base::boolalpha) != 0</tt>, this


### PR DESCRIPTION
I have corrected a few minor mistakes, such as `uniquily` (instead of `uniquely`).